### PR TITLE
add react-habitat as container-system for multi-site component support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-habitat": "^0.4.2",
     "react-hot-loader": "^3.0.0-beta.7"
   }
 }

--- a/server/views/admin.php
+++ b/server/views/admin.php
@@ -1,1 +1,1 @@
-<div id="root"></div>
+<div data-component="App"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,20 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactHabitat from 'react-habitat';
 import App from './components/App.js';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+class WP_React_Boilerplate extends ReactHabitat.Bootstrapper {
+    constructor(){
+        super();
+
+        // Create a new container builder
+        var container = new ReactHabitat.Container();
+
+        // Register your top level component(s) (ie mini/child apps)
+        container.register('App', App);
+
+        // Finally, set the container
+        this.setContainer(container);
+    }
+}
+
+// Always export a 'new' instance so it immediately evokes
+export default new WP_React_Boilerplate();


### PR DESCRIPTION
Hey,

first of all: thanks for this boilerplate! It helped me a lot to get my head around conecting wordpress with react.

Let's come to my request:
When developing a plugin it is necessary to develop different components for mutliple sites. Loading a bundled version of my react-components at start leads to some errors.

If I declared multiple components and just want to display one of them, I get an initialization-error => the other components could not be instantiated because there is no DOM-Element. So I needed to check manually if the DOM-Element exists and so on...

My conclusion: I came up with react-habitat which is like a container-system for components. You register components to this container once and can use them across multiple sites. In my opinion this would be an awsome extension to a cms-based reactive plugin.

What do you think? Is there another/better solution for this?